### PR TITLE
fix: allow omitted workspace insight folder ID

### DIFF
--- a/src/todoist-api.insights.test.ts
+++ b/src/todoist-api.insights.test.ts
@@ -168,6 +168,23 @@ describe('TodoistApi insights endpoints', () => {
     })
 
     describe('getWorkspaceInsights', () => {
+        test('accepts responses that omit folderId', async () => {
+            const mockResponse = {
+                project_insights: [],
+            }
+            server.use(
+                http.get(`${getSyncBaseUri()}workspaces/456/insights`, () => {
+                    return HttpResponse.json(mockResponse, { status: 200 })
+                }),
+            )
+            const api = getTarget()
+
+            const result = await api.getWorkspaceInsights('456')
+
+            expect(result.folderId).toBeUndefined()
+            expect(result.projectInsights).toEqual([])
+        })
+
         test('returns workspace insights from rest client', async () => {
             const mockResponse = {
                 folder_id: null,

--- a/src/types/insights/types.ts
+++ b/src/types/insights/types.ts
@@ -112,7 +112,7 @@ export const ProjectInsightSchema = z.object({
 export type ProjectInsight = z.infer<typeof ProjectInsightSchema>
 
 export const WorkspaceInsightsSchema = z.object({
-    folderId: z.string().nullable(),
+    folderId: z.string().nullable().optional(),
     projectInsights: z.array(ProjectInsightSchema),
 })
 /** Workspace insights grouped by folder. */


### PR DESCRIPTION
## Summary
- accept workspace insight responses that omit `folder_id`
- add regression coverage for the live API response shape

## Testing
- `npm test -- src/todoist-api.insights.test.ts`
- `npm run check`

`npm run ts-compile-check` remains blocked by unrelated existing test type errors.

Closes #654