### PR TITLE
fix: serialize task IDs as comma-separated query parameter

### DIFF
--- a/src/clients/task-client.ts
+++ b/src/clients/task-client.ts
@@ -67,7 +67,10 @@ export class TaskClient extends BaseClient {
             relativePath: ENDPOINT_REST_TASKS,
             apiToken: this.authToken,
             customFetch: this.customFetch,
-            payload: args,
+            payload: {
+                ...args,
+                ...(args.ids ? { ids: args.ids.join(',') } : {}),
+            },
         })
 
         return {

--- a/src/clients/task-client.ts
+++ b/src/clients/task-client.ts
@@ -69,7 +69,7 @@ export class TaskClient extends BaseClient {
             customFetch: this.customFetch,
             payload: {
                 ...args,
-                ...(args.ids ? { ids: args.ids.join(',') } : {}),
+                ...spreadIfDefined(args.ids, (ids) => ({ ids: ids.join(',') })),
             },
         })
 

--- a/src/todoist-api.tasks.test.ts
+++ b/src/todoist-api.tasks.test.ts
@@ -441,6 +441,21 @@ describe('TodoistApi task endpoints', () => {
             expect(results).toEqual(tasks)
             expect(nextCursor).toBe('123')
         })
+
+        test('serializes IDs as a comma-separated query parameter', async () => {
+            let capturedUrl = ''
+            server.use(
+                http.get(`${getSyncBaseUri()}${ENDPOINT_REST_TASKS}`, ({ request }) => {
+                    capturedUrl = request.url
+                    return HttpResponse.json({ results: [], nextCursor: null }, { status: 200 })
+                }),
+            )
+            const api = getTarget()
+
+            await api.getTasks({ ids: ['id-one', 'id-two'] })
+
+            expect(new URL(capturedUrl).searchParams.get('ids')).toBe('id-one,id-two')
+        })
     })
 
     describe('getTasksByFilter', () => {


### PR DESCRIPTION
## Summary
- serialize `getTasks({ ids })` as a comma-separated query value
- add request-level regression coverage

## Testing
- `npm test -- src/todoist-api.tasks.test.ts`
- `npm run check`

Closes #653