### PR TITLE
fix!: drop workspace insight folder ID and health task recommendations

### DIFF
--- a/src/todoist-api.insights.test.ts
+++ b/src/todoist-api.insights.test.ts
@@ -72,7 +72,6 @@ describe('TodoistApi insights endpoints', () => {
                 status: 'ON_TRACK',
                 description: 'Project is on track',
                 description_summary: 'On track',
-                task_recommendations: [{ task_id: '1', recommendation: 'Complete soon' }],
                 project_id: '123',
                 updated_at: '2025-01-15T00:00:00Z',
                 is_stale: false,
@@ -88,11 +87,8 @@ describe('TodoistApi insights endpoints', () => {
             const result = await api.getProjectHealth('123')
 
             expect(result.status).toBe('ON_TRACK')
-            expect(result.taskRecommendations).toHaveLength(1)
-            expect(result.taskRecommendations![0]).toMatchObject({
-                taskId: '1',
-                recommendation: 'Complete soon',
-            })
+            expect(result.descriptionSummary).toBe('On track')
+            expect(result.projectId).toBe('123')
         })
     })
 
@@ -168,7 +164,7 @@ describe('TodoistApi insights endpoints', () => {
     })
 
     describe('getWorkspaceInsights', () => {
-        test('accepts responses that omit folderId', async () => {
+        test('returns an empty list when the workspace has no insights', async () => {
             const mockResponse = {
                 project_insights: [],
             }
@@ -181,13 +177,11 @@ describe('TodoistApi insights endpoints', () => {
 
             const result = await api.getWorkspaceInsights('456')
 
-            expect(result.folderId).toBeUndefined()
             expect(result.projectInsights).toEqual([])
         })
 
         test('returns workspace insights from rest client', async () => {
             const mockResponse = {
-                folder_id: null,
                 project_insights: [
                     {
                         project_id: '123',
@@ -214,7 +208,6 @@ describe('TodoistApi insights endpoints', () => {
 
             const result = await api.getWorkspaceInsights('456')
 
-            expect(result.folderId).toBeNull()
             expect(result.projectInsights).toHaveLength(1)
             expect(result.projectInsights[0].health?.status).toBe('ON_TRACK')
             expect(result.projectInsights[0].progress?.progressPercent).toBe(33)

--- a/src/types/insights/types.ts
+++ b/src/types/insights/types.ts
@@ -36,24 +36,16 @@ export const HEALTH_STATUSES = [
 /** Health status of a project. */
 export type HealthStatus = (typeof HEALTH_STATUSES)[number]
 
-export const TaskRecommendationSchema = z.object({
-    taskId: z.string(),
-    recommendation: z.string(),
-})
-/** A recommendation for a specific task. */
-export type TaskRecommendation = z.infer<typeof TaskRecommendationSchema>
-
 export const ProjectHealthSchema = z.object({
     status: z.enum(HEALTH_STATUSES),
     description: z.string().nullable().optional(),
     descriptionSummary: z.string().nullable().optional(),
-    taskRecommendations: z.array(TaskRecommendationSchema).nullable().optional(),
     projectId: z.string().nullable().optional(),
     updatedAt: z.coerce.date().nullable().optional(),
     isStale: z.boolean().default(false),
     updateInProgress: z.boolean().default(false),
 })
-/** Project health status and recommendations. */
+/** Project health status. */
 export type ProjectHealth = z.infer<typeof ProjectHealthSchema>
 
 export const ProjectMetricsSchema = z.object({
@@ -112,8 +104,7 @@ export const ProjectInsightSchema = z.object({
 export type ProjectInsight = z.infer<typeof ProjectInsightSchema>
 
 export const WorkspaceInsightsSchema = z.object({
-    folderId: z.string().nullable().optional(),
     projectInsights: z.array(ProjectInsightSchema),
 })
-/** Workspace insights grouped by folder. */
+/** Insights for the projects in a workspace. */
 export type WorkspaceInsights = z.infer<typeof WorkspaceInsightsSchema>


### PR DESCRIPTION
## Short description

Two insights fields have outlived the API that fed them, and this removes both.

`WorkspaceInsights.folderId` — the API removed `folder_id` from the workspace insights response in Doist/todoist#27366 (10 April). `WorkspaceInsightsAPIView` in `openapi.json` is now `['project_insights']` and nothing else. #655 already relaxed the field to `.nullable().optional()` to stop the parse errors that removal caused, but the field itself stayed, so callers read a permanent `undefined`.

`ProjectHealth.taskRecommendations` — removed from project health in Doist/todoist#28902 (3 July). `ProjectHealthRestView` is now `status, description, description_summary, project_id, updated_at, is_stale, update_in_progress`, and `task_recommendations` appears zero times in the backend or `openapi.json`.

Because both were optional, nothing failed loudly: consumers just quietly got `undefined` forever. Downstream this had real cost — todoist-mcp shipped a `get-project-health` tool that rendered a "Task Recommendations" section which could never appear, and advertised "task-level recommendations" in its tool description. Removing the fields turns a silent dead end into a compile error at the point of use.

`TaskRecommendation` and `TaskRecommendationSchema` go with them, as nothing else references them.

## Breaking change

`WorkspaceInsights.folderId`, `ProjectHealth.taskRecommendations`, `TaskRecommendation` and `TaskRecommendationSchema` are removed. Any code reading those fields was already receiving `undefined`, so behaviour does not change — only the types do.

## Notes

`npm run ts-compile-check` reports 4 pre-existing errors on `main` (`todoist-api.apps.test.ts`, `todoist-api.app-installations.test.ts`, `todoist-api.ui-extensions.test.ts`), unrelated to this change and unchanged by it. `npm run check` is clean and all 622 tests pass.