### PR TITLE
fix: parse live notification variants

### DIFF
--- a/src/todoist-api.sync.test.ts
+++ b/src/todoist-api.sync.test.ts
@@ -127,6 +127,86 @@ describe('TodoistApi sync endpoint', () => {
                 }),
             ).rejects.toThrow(ZodError)
         })
+
+        test('parses live notification variants returned by the Sync API', async () => {
+            const createdAt = '2026-08-12T12:00:00Z'
+            server.use(
+                http.post(`${getSyncBaseUri()}${ENDPOINT_SYNC}`, () => {
+                    return HttpResponse.json(
+                        {
+                            live_notifications: [
+                                {
+                                    id: 'notification-1',
+                                    created_at: createdAt,
+                                    from_uid: 'user-1',
+                                    notification_type: 'item_completed',
+                                    is_unread: true,
+                                    responsible_uid: null,
+                                    assigned_by_uid: null,
+                                },
+                                {
+                                    id: 'notification-2',
+                                    created_at: createdAt,
+                                    from_uid: 'user-1',
+                                    notification_type: 'user_removed_from_project',
+                                    is_unread: true,
+                                    from_user: {
+                                        email: 'user@example.com',
+                                        full_name: 'Example User',
+                                        id: 123,
+                                        image_id: null,
+                                    },
+                                },
+                                {
+                                    id: 'notification-3',
+                                    created_at: createdAt,
+                                    notification_type: 'workspace_invitation_accepted',
+                                    is_unread: true,
+                                },
+                            ],
+                        },
+                        { status: 200 },
+                    )
+                }),
+            )
+            const api = getTarget()
+
+            const response = await api.sync({
+                resourceTypes: ['live_notifications'],
+                syncToken: '*',
+            })
+
+            expect(response.liveNotifications).toEqual([
+                {
+                    id: 'notification-1',
+                    createdAt: new Date(createdAt),
+                    fromUid: 'user-1',
+                    notificationType: 'item_completed',
+                    isUnread: true,
+                    responsibleUid: null,
+                    assignedByUid: null,
+                },
+                {
+                    id: 'notification-2',
+                    createdAt: new Date(createdAt),
+                    fromUid: 'user-1',
+                    notificationType: 'user_removed_from_project',
+                    isUnread: true,
+                    fromUser: {
+                        email: 'user@example.com',
+                        fullName: 'Example User',
+                        id: '123',
+                        imageId: null,
+                    },
+                },
+                {
+                    id: 'notification-3',
+                    createdAt: new Date(createdAt),
+                    notificationType: 'workspace_invitation_accepted',
+                    isUnread: true,
+                },
+            ])
+        })
     })
 })
 

--- a/src/types/sync/resources/live-notifications.ts
+++ b/src/types/sync/resources/live-notifications.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
 
+import { StringOrNumberSchema } from '../../common'
+
 /**
  * Live notification resource from the Sync API.
  *
@@ -11,7 +13,7 @@ import { z } from 'zod'
 export const LiveNotificationSchema = z.looseObject({
     id: z.string(),
     createdAt: z.coerce.date(),
-    fromUid: z.string(),
+    fromUid: z.string().optional(),
     notificationType: z.string(),
     isUnread: z.boolean(),
     // Commonly present optional fields
@@ -19,13 +21,13 @@ export const LiveNotificationSchema = z.looseObject({
     invitationId: z.string().optional(),
     itemId: z.string().optional(),
     itemContent: z.string().optional(),
-    responsibleUid: z.string().optional(),
-    assignedByUid: z.string().optional(),
+    responsibleUid: z.string().nullable().optional(),
+    assignedByUid: z.string().nullable().optional(),
     fromUser: z
         .object({
             email: z.string(),
             fullName: z.string(),
-            id: z.string(),
+            id: StringOrNumberSchema,
             imageId: z.string().nullable(),
         })
         .optional(),

--- a/src/types/sync/resources/resources.test.ts
+++ b/src/types/sync/resources/resources.test.ts
@@ -470,6 +470,35 @@ describe('Sync resource schemas', () => {
             expect(result.itemContent).toBe('Buy milk')
         })
 
+        test('accepts live API notification variants', () => {
+            const withNullableAssignees = LiveNotificationSchema.parse({
+                ...validNotification,
+                responsibleUid: null,
+                assignedByUid: null,
+            })
+            expect(withNullableAssignees.responsibleUid).toBeNull()
+            expect(withNullableAssignees.assignedByUid).toBeNull()
+
+            const withNumericFromUserId = LiveNotificationSchema.parse({
+                ...validNotification,
+                fromUser: {
+                    email: 'user@example.com',
+                    fullName: 'Example User',
+                    id: 456,
+                    imageId: null,
+                },
+            })
+            expect(withNumericFromUserId.fromUser?.id).toBe('456')
+
+            const withoutFromUid = LiveNotificationSchema.parse({
+                id: 'ln2',
+                createdAt: '2024-01-01T00:00:00Z',
+                notificationType: 'workspace_invitation_accepted',
+                isUnread: true,
+            })
+            expect(withoutFromUid.fromUid).toBeUndefined()
+        })
+
         test('throws on invalid data', () => {
             expect(() => LiveNotificationSchema.parse({ id: 'ln1' })).toThrow(ZodError)
         })


### PR DESCRIPTION
## Summary

I discovered this through `td notification list`, which was failing before the
CLI's notification parser could run. Tracing that back showed the SDK was
rejecting valid `live_notifications` returned by the Sync API.

Some live notification variants can omit `from_uid`, return `null` for
`responsible_uid` or `assigned_by_uid`, and include a numeric `from_user.id`.
This updates `LiveNotificationSchema` to accept those shapes while continuing to
normalize the embedded `fromUser.id` value to a string.
