### PR TITLE
fix: send uidsToNotify as a list, not a comma-joined string

### DIFF
--- a/src/clients/comment-client.ts
+++ b/src/clients/comment-client.ts
@@ -62,7 +62,9 @@ export class CommentClient extends BaseClient {
             customFetch: this.customFetch,
             payload: {
                 ...rest,
-                ...(uidsToNotify ? { uidsToNotify: uidsToNotify.join(',') } : {}),
+                // The API expects a list; a comma-joined string is rejected
+                // with INVALID_ARGUMENT_VALUE on uids_to_notify.
+                ...(uidsToNotify?.length ? { uidsToNotify } : {}),
             },
             requestId: requestId,
         })

--- a/src/todoist-api.comments.test.ts
+++ b/src/todoist-api.comments.test.ts
@@ -98,7 +98,7 @@ describe('TodoistApi comment endpoints', () => {
             expect(capturedBody).not.toHaveProperty('uids_to_notify')
         })
 
-        test('sends uidsToNotify as a comma-separated string when defined', async () => {
+        test('sends uidsToNotify as a list when defined', async () => {
             let capturedBody: Record<string, unknown> = {}
             server.use(
                 http.post(`${getSyncBaseUri()}${ENDPOINT_REST_COMMENTS}`, async ({ request }) => {
@@ -113,7 +113,22 @@ describe('TodoistApi comment endpoints', () => {
                 uidsToNotify: ['user1', 'user2', 'user3'],
             })
 
-            expect(capturedBody.uids_to_notify).toBe('user1,user2,user3')
+            expect(capturedBody.uids_to_notify).toEqual(['user1', 'user2', 'user3'])
+        })
+
+        test('does not send uidsToNotify when empty', async () => {
+            let capturedBody: Record<string, unknown> = {}
+            server.use(
+                http.post(`${getSyncBaseUri()}${ENDPOINT_REST_COMMENTS}`, async ({ request }) => {
+                    capturedBody = (await request.json()) as Record<string, unknown>
+                    return HttpResponse.json(DEFAULT_RAW_COMMENT, { status: 200 })
+                }),
+            )
+            const api = getTarget()
+
+            await api.addComment({ ...addCommentArgs, uidsToNotify: [] })
+
+            expect(capturedBody).not.toHaveProperty('uids_to_notify')
         })
     })
 


### PR DESCRIPTION
`addComment` joined `uidsToNotify` into a comma-separated string before sending it. The API expects a list and rejects the string outright, so no caller could notify anyone about a comment — the whole call failed the moment `uidsToNotify` was set:

```
400 INVALID_ARGUMENT_VALUE
argument: uids_to_notify
expected: "Input should be a valid list"
```

This passes the array through instead, and omits the key when the list is empty so an explicit "notify nobody" doesn't send a meaningless field. An empty list is accepted by the API and stored as `null`, so omitting it changes nothing on the wire beyond dropping a redundant field.

Found while adding comment notifications to [todoist-mcp](https://github.com/Doist/todoist-mcp/issues/509), which is blocked on this. `todoist-cli` never sets `uidsToNotify`, which is why nothing caught it before.

## Verification

Confirmed against the live API before and after — a curl with `"uids_to_notify": ["9876543"]` succeeds where the comma-joined string 400s, and after the fix a comment added through the SDK comes back with `uids_to_notify` populated.

The existing unit test asserted the comma-joined string, so it has been updated to assert the list, and a case for the empty list added. Full suite passes (623 tests). The `ts-compile-check` failures in `todoist-api.apps.test.ts` and `todoist-api.ui-extensions.test.ts` are pre-existing on `main` and untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
