### PR TITLE
feat(filters): add description to filter types

### DIFF
--- a/src/types/sync/commands/filters.ts
+++ b/src/types/sync/commands/filters.ts
@@ -3,6 +3,7 @@ import type { ColorKey } from '../../../utils/colors'
 export type FilterAddArgs = {
     name: string
     query: string
+    description?: string | null
     color?: ColorKey
     itemOrder?: number
     isFavorite?: boolean
@@ -12,6 +13,7 @@ export type FilterUpdateArgs = {
     id: string
     name?: string
     query?: string
+    description?: string | null
     color?: ColorKey
     itemOrder?: number
     isFavorite?: boolean

--- a/src/types/sync/commands/workspace-filters.ts
+++ b/src/types/sync/commands/workspace-filters.ts
@@ -4,6 +4,7 @@ export type WorkspaceFilterAddArgs = {
     workspaceId: string
     name: string
     query: string
+    description?: string | null
     color?: ColorKey
     itemOrder?: number
     isFavorite?: boolean
@@ -13,6 +14,7 @@ export type WorkspaceFilterUpdateArgs = {
     id: string
     name?: string
     query?: string
+    description?: string | null
     color?: ColorKey
     itemOrder?: number
     isFavorite?: boolean

--- a/src/types/sync/resources/filters.ts
+++ b/src/types/sync/resources/filters.ts
@@ -4,6 +4,7 @@ export const FilterSchema = z.looseObject({
     id: z.string(),
     name: z.string(),
     query: z.string(),
+    description: z.string().nullish(),
     color: z.string(),
     isDeleted: z.boolean(),
     isFavorite: z.boolean(),

--- a/src/types/sync/resources/workspace-filters.ts
+++ b/src/types/sync/resources/workspace-filters.ts
@@ -5,6 +5,7 @@ export const WorkspaceFilterSchema = z.looseObject({
     workspaceId: z.string(),
     name: z.string(),
     query: z.string(),
+    description: z.string().nullish(),
     color: z.string(),
     itemOrder: z.number().int(),
     isDeleted: z.boolean(),

--- a/src/types/webhooks/filters.test.ts
+++ b/src/types/webhooks/filters.test.ts
@@ -38,6 +38,26 @@ describe('filter:* payloads', () => {
         expect(payload.eventData.isFavorite).toBe(true)
     })
 
+    test('filter:added carries a description when the filter has one', () => {
+        const payload = parseWebhookPayload(
+            envelope('filter:added', rawFilter({ description: 'Everything due this week' })),
+        )
+        if (payload.eventName !== 'filter:added') throw new Error('expected filter:added')
+
+        expect(payload.eventData.description).toBe('Everything due this week')
+    })
+
+    test('a filter with no description parses whether the key is null or absent', () => {
+        // The column is nullable and predates every existing filter, so both shapes
+        // reach clients. Rejecting either would fail the whole payload.
+        for (const raw of [rawFilter({ description: null }), rawFilter()]) {
+            const payload = parseWebhookPayload(envelope('filter:added', raw))
+            if (payload.eventName !== 'filter:added') throw new Error('expected filter:added')
+
+            expect(payload.eventData.description ?? null).toBeNull()
+        }
+    })
+
     test('filter:deleted carries isDeleted=true', () => {
         const payload = parseWebhookPayload(
             envelope('filter:deleted', rawFilter({ is_deleted: true })),


### PR DESCRIPTION
Adds `description` to the filter types so the CLI and the MCP can read and set it.

This is what the other two are waiting on. The MCP does not compile without it, and the CLI compiles only by accident.

- Optional and nullable throughout. Filters from before the field send nothing, filters without a description send null.
- Webhook payloads reuse `FilterSchema`, so they pick it up for free.
- The API serving this is Doist/Todoist#29669, still draft.

Consumers: Doist/todoist-cli#486, Doist/todoist-mcp#581

🤖 Generated with [Claude Code](https://claude.com/claude-code)
