### PR TITLE
fix: align Sync resource schemas with API responses

### DIFF
--- a/src/todoist-api.sync.test.ts
+++ b/src/todoist-api.sync.test.ts
@@ -267,6 +267,39 @@ describe('parseSyncResponse', () => {
         expect(result.folders).toEqual([DEFAULT_FOLDER])
     })
 
+    test('accepts Sync labels without order and preserves deletion state', () => {
+        const label = {
+            id: 'label-1',
+            name: 'Waiting',
+            color: 'blue',
+            isFavorite: false,
+            isDeleted: true,
+        }
+
+        const result = parseSyncResponse({ labels: [label] })
+
+        expect(result.labels).toEqual([label])
+    })
+
+    test.each(['absolute', 'relative'] as const)(
+        'accepts a null due date on a Sync %s reminder',
+        (type) => {
+            const reminder = {
+                id: 'reminder-1',
+                notifyUid: 'user-1',
+                itemId: 'task-1',
+                isDeleted: true,
+                type,
+                due: null,
+                ...(type === 'relative' ? { minuteOffset: 30 } : {}),
+            }
+
+            const result = parseSyncResponse({ reminders: [reminder] })
+
+            expect(result.reminders).toEqual([reminder])
+        },
+    )
+
     test('throws ZodError for invalid items', () => {
         const response = {
             items: [{ invalid: true }],

--- a/src/types/sync/resources/index.ts
+++ b/src/types/sync/resources/index.ts
@@ -1,4 +1,5 @@
 export * from './filters'
+export * from './labels'
 export * from './collaborators'
 export * from './folders'
 export * from './tooltips'

--- a/src/types/sync/resources/labels.ts
+++ b/src/types/sync/resources/labels.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+
+import { LabelSchema } from '../../labels/types'
+
+/** A label returned by the Sync API. */
+export const SyncLabelSchema = LabelSchema.extend({
+    order: z.number().int().nullable().optional(),
+    isDeleted: z.boolean().optional(),
+})
+
+/** Represents a label returned by the Sync API. */
+export type SyncLabel = z.infer<typeof SyncLabelSchema>

--- a/src/types/sync/resources/reminders.ts
+++ b/src/types/sync/resources/reminders.ts
@@ -64,3 +64,23 @@ export const ReminderSchema = z.discriminatedUnion('type', [
 ])
 
 export type Reminder = z.infer<typeof ReminderSchema>
+
+export const SyncAbsoluteReminderSchema = AbsoluteReminderSchema.extend({
+    due: DueDateSchema.nullable(),
+})
+
+export type SyncAbsoluteReminder = z.infer<typeof SyncAbsoluteReminderSchema>
+
+export const SyncRelativeReminderSchema = RelativeReminderSchema.extend({
+    due: DueDateSchema.nullable().optional(),
+})
+
+export type SyncRelativeReminder = z.infer<typeof SyncRelativeReminderSchema>
+
+export const SyncReminderSchema = z.discriminatedUnion('type', [
+    LocationReminderSchema,
+    SyncAbsoluteReminderSchema,
+    SyncRelativeReminderSchema,
+])
+
+export type SyncReminder = z.infer<typeof SyncReminderSchema>

--- a/src/types/sync/response.ts
+++ b/src/types/sync/response.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod'
 
-import { LabelSchema } from '../labels/types'
 import { ProjectSchema } from '../projects/types'
 import { SectionSchema } from '../sections/types'
 import { TaskSchema } from '../tasks/types'
@@ -15,7 +14,8 @@ import {
     WorkspaceFilterSchema,
     CalendarSchema,
     CalendarAccountSchema,
-    ReminderSchema,
+    SyncLabelSchema,
+    SyncReminderSchema,
     LocationReminderSchema,
     CompletedInfoSchema,
     ViewOptionsSchema,
@@ -46,11 +46,11 @@ export const SyncResponseSchema = z.looseObject({
     items: z.array(TaskSchema).optional(),
     projects: z.array(ProjectSchema).optional(),
     sections: z.array(SectionSchema).optional(),
-    labels: z.array(LabelSchema).optional(),
+    labels: z.array(SyncLabelSchema).optional(),
     notes: z.array(NoteSchema).optional(),
     projectNotes: z.array(NoteSchema).optional(),
     filters: z.array(FilterSchema).optional(),
-    reminders: z.array(ReminderSchema).optional(),
+    reminders: z.array(SyncReminderSchema).optional(),
     remindersLocation: z.array(LocationReminderSchema).optional(),
     locations: z.array(z.record(z.string(), z.unknown())).optional(),
     user: SyncUserSchema.optional(),


### PR DESCRIPTION
## Summary

- add a Sync-specific label schema where `order` can be absent and deletion state is preserved
- add Sync-specific reminder schemas that accept `due: null` without weakening REST reminder types
- use the Sync-specific schemas in `SyncResponseSchema`

> [!IMPORTANT]
> I wonder why we need different schemas for sync vs REST APIs. I'm investigating in the backend repo to see if this is intended or if it's something that we ideally move away from in the APIs in the long run. 